### PR TITLE
Adding a tintColor variable to config

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -24,6 +24,7 @@ class ViewController: UIViewController {
         let config = FolioReaderConfig()
         config.shouldHideNavigationOnTap = sampleNum == 1 ? true : false
 //        config.allowSharing = false
+//        config.tintColor = UIColor.blueColor()
 //        config.toolBarTintColor = UIColor.redColor()
 //        config.toolBarBackgroundColor = UIColor.purpleColor()
 //        config.menuTextColor = UIColor.brownColor()

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -55,7 +55,7 @@ class ScrollScrubber: NSObject, UIScrollViewDelegate {
         
         super.init()
         
-        let color = readerConfig.toolBarBackgroundColor
+        let color = readerConfig.tintColor
         slider = UISlider()
         slider.layer.anchorPoint = CGPoint(x: 0, y: 0)
         slider.transform = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
@@ -303,7 +303,7 @@ class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICollectio
 
     func configureNavBar() {
         let navBackground = FolioReader.sharedInstance.nightMode ? readerConfig.nightModeMenuBackground : UIColor.whiteColor()
-        let tintColor = readerConfig.toolBarBackgroundColor
+        let tintColor = readerConfig.tintColor
         let navText = FolioReader.sharedInstance.nightMode ? UIColor.whiteColor() : UIColor.blackColor()
         let font = UIFont(name: "Avenir-Light", size: 17)!
         setTranslucentNavigation(color: navBackground, tintColor: tintColor, titleColor: navText, andFont: font)
@@ -312,9 +312,9 @@ class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICollectio
     func configureNavBarButtons() {
 
         // Navbar buttons
-        let shareIcon = UIImage(readerImageNamed: "btn-navbar-share")!.imageTintColor(readerConfig.toolBarBackgroundColor).imageWithRenderingMode(.AlwaysOriginal)
-        let audioIcon = UIImage(readerImageNamed: "man-speech-icon")!.imageTintColor(readerConfig.toolBarBackgroundColor).imageWithRenderingMode(.AlwaysOriginal)
-        let menuIcon = UIImage(readerImageNamed: "btn-navbar-menu")!.imageTintColor(readerConfig.toolBarBackgroundColor).imageWithRenderingMode(.AlwaysOriginal)
+        let shareIcon = UIImage(readerImageNamed: "btn-navbar-share")!.imageTintColor(readerConfig.tintColor).imageWithRenderingMode(.AlwaysOriginal)
+        let audioIcon = UIImage(readerImageNamed: "man-speech-icon")!.imageTintColor(readerConfig.tintColor).imageWithRenderingMode(.AlwaysOriginal)
+        let menuIcon = UIImage(readerImageNamed: "btn-navbar-menu")!.imageTintColor(readerConfig.tintColor).imageWithRenderingMode(.AlwaysOriginal)
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: menuIcon, style: UIBarButtonItemStyle.Plain, target: self, action:"toggleMenu:")
 
@@ -435,7 +435,7 @@ class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICollectio
         var html = try? String(contentsOfFile: resource.fullHref, encoding: NSUTF8StringEncoding)
         
         if readerConfig.mediaOverlayColor == nil {
-           readerConfig.mediaOverlayColor = readerConfig.toolBarBackgroundColor.highlightColor()
+           readerConfig.mediaOverlayColor = readerConfig.tintColor.highlightColor()
         }
 
         let mediaOverlayStyle = "background: \(readerConfig.mediaOverlayColor.hexString(false)) !important; border-radius: 3px; padding-right: 4px; margin-right: -4px;"

--- a/Source/FolioReaderConfig.swift
+++ b/Source/FolioReaderConfig.swift
@@ -10,6 +10,7 @@ import UIKit
 
 public class FolioReaderConfig: NSObject {
     // Reader Colors
+    public var tintColor: UIColor!
     public var toolBarBackgroundColor: UIColor!
     public var toolBarTintColor: UIColor!
     public var menuBackgroundColor: UIColor!
@@ -47,7 +48,8 @@ public class FolioReaderConfig: NSObject {
     // MARK: - Init with defaults
     
     public override init() {
-        self.toolBarBackgroundColor = UIColor(rgba: "#6ACC50")
+        self.tintColor = UIColor(rgba: "#6ACC50")
+        self.toolBarBackgroundColor = self.tintColor
         self.toolBarTintColor = UIColor.whiteColor()
         self.menuBackgroundColor = UIColor(rgba: "#F5F5F5")
         self.menuSeparatorColor = UIColor(rgba: "#D7D7D7")

--- a/Source/FolioReaderFontsMenu.swift
+++ b/Source/FolioReaderFontsMenu.swift
@@ -38,7 +38,7 @@ class FolioReaderFontsMenu: UIViewController, SMSegmentViewDelegate {
         view.addSubview(menuView)
         
         let normalColor = UIColor(white: 0.5, alpha: 0.7)
-        let selectedColor = readerConfig.toolBarBackgroundColor
+        let selectedColor = readerConfig.tintColor
         let sun = UIImage(readerImageNamed: "icon-sun")
         let moon = UIImage(readerImageNamed: "icon-moon")
         let fontSmall = UIImage(readerImageNamed: "icon-font-small")

--- a/Source/FolioReaderHighlightList.swift
+++ b/Source/FolioReaderHighlightList.swift
@@ -29,7 +29,7 @@ class FolioReaderHighlightList: UITableViewController {
     
     func configureNavBar() {
         let navBackground = FolioReader.sharedInstance.nightMode ? readerConfig.nightModeMenuBackground : UIColor.whiteColor()
-        let tintColor = readerConfig.toolBarBackgroundColor
+        let tintColor = readerConfig.tintColor
         let navText = FolioReader.sharedInstance.nightMode ? UIColor.whiteColor() : UIColor.blackColor()
         let font = UIFont(name: "Avenir-Light", size: 17)!
         setTranslucentNavigation(color: navBackground, tintColor: tintColor, titleColor: navText, andFont: font)

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -184,12 +184,12 @@ class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRecogni
             
             if #available(iOS 9.0, *) {
                 let safariVC = SFSafariViewController(URL: request.URL!)
-                safariVC.view.tintColor = readerConfig.toolBarBackgroundColor
+                safariVC.view.tintColor = readerConfig.tintColor
                 FolioReader.sharedInstance.readerCenter.presentViewController(safariVC, animated: true, completion: nil)
             } else {
                 let webViewController = WebViewController(url: request.URL!)
                 let nav = UINavigationController(rootViewController: webViewController)
-                nav.view.tintColor = readerConfig.toolBarBackgroundColor
+                nav.view.tintColor = readerConfig.tintColor
                 FolioReader.sharedInstance.readerCenter.presentViewController(nav, animated: true, completion: nil)
             }
             
@@ -413,7 +413,7 @@ extension UIWebView {
         userInteractionEnabled = true
         
         let vc = UIReferenceLibraryViewController(term: selectedText! )
-        vc.view.tintColor = readerConfig.toolBarBackgroundColor
+        vc.view.tintColor = readerConfig.tintColor
         FolioReader.sharedInstance.readerContainer.showViewController(vc, sender: nil)
     }
 

--- a/Source/FolioReaderPlayerMenu.swift
+++ b/Source/FolioReaderPlayerMenu.swift
@@ -43,7 +43,7 @@ class FolioReaderPlayerMenu: UIViewController, SMSegmentViewDelegate {
         
 
         let normalColor = UIColor(white: 0.5, alpha: 0.7)
-        let selectedColor = readerConfig.toolBarBackgroundColor
+        let selectedColor = readerConfig.tintColor
         let size = 55
         let padX = 32
         // @NOTE: could this be improved/simplified with autolayout?

--- a/Source/FolioReaderSidePanel.swift
+++ b/Source/FolioReaderSidePanel.swift
@@ -132,7 +132,7 @@ class FolioReaderSidePanel: UIViewController, UITableViewDelegate, UITableViewDa
         // Mark current reading chapter
         if let currentPageNumber = currentPageNumber {
             if let resource = book.spine.spineReferences[currentPageNumber-1].resource {
-                cell.indexLabel.textColor = tocReference.resource.href == resource.href ? readerConfig.toolBarBackgroundColor : readerConfig.menuTextColor
+                cell.indexLabel.textColor = tocReference.resource.href == resource.href ? readerConfig.tintColor : readerConfig.menuTextColor
             }
         }
         


### PR DESCRIPTION
The green background color is used as a "tint" in more places than as a "background". So adding a `tintColor` with the `toolBarBackgroundColor` defaulting to the same color makes more sense.
