### PR TITLE
Use dark color theme in FolioReaderHighlightList when in night mode

### DIFF
--- a/Source/FolioReaderHighlightList.swift
+++ b/Source/FolioReaderHighlightList.swift
@@ -16,6 +16,7 @@ class FolioReaderHighlightList: UITableViewController {
         super.viewDidLoad()
 
         tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
+        tableView.backgroundColor = FolioReader.sharedInstance.nightMode ? UIColor.blackColor() : UIColor.whiteColor()
         highlights = Highlight.allByBookId((kBookId as NSString).stringByDeletingPathExtension)
         title = readerConfig.localizedHighlightsTitle
         
@@ -53,6 +54,7 @@ class FolioReaderHighlightList: UITableViewController {
     
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier(reuseIdentifier, forIndexPath: indexPath) 
+        cell.backgroundColor = FolioReader.sharedInstance.nightMode ? UIColor.blackColor() : UIColor.whiteColor()
 
         let highlight = highlights[indexPath.row]
         


### PR DESCRIPTION
In night mode the table view and its cell are still white, which makes it uncomfortable to read. I changed the background color of  the table view and its cell to black when in night mode. 
