### PR TITLE
Fix retain cycles

### DIFF
--- a/Source/FolioReaderAudioPlayer.swift
+++ b/Source/FolioReaderAudioPlayer.swift
@@ -10,7 +10,7 @@ import UIKit
 import AVFoundation
 import MediaPlayer
 
-protocol FolioReaderAudioPlayerDelegate {
+protocol FolioReaderAudioPlayerDelegate: class {
     /**
      Notifies that Player read all sentence
      */
@@ -18,7 +18,7 @@ protocol FolioReaderAudioPlayerDelegate {
 }
 
 class FolioReaderAudioPlayer: NSObject, AVAudioPlayerDelegate, AVSpeechSynthesizerDelegate {
-    var delegate: FolioReaderAudioPlayerDelegate!
+    weak var delegate: FolioReaderAudioPlayerDelegate!
     var isTextToSpeech = false
     var synthesizer: AVSpeechSynthesizer!
     var playing = false

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -38,7 +38,7 @@ enum ScrollDirection: Int {
 
 class ScrollScrubber: NSObject, UIScrollViewDelegate {
     
-    var delegate: FolioReaderCenter!
+    weak var delegate: FolioReaderCenter!
     var showSpeed = 0.6
     var hideSpeed = 0.6
     var hideDelay = 1.0
@@ -232,7 +232,7 @@ class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICollectio
     var totalPages: Int!
     var tempFragment: String?
     var currentPage: FolioReaderPage!
-    var folioReaderContainer: FolioReaderContainer!
+    weak var folioReaderContainer: FolioReaderContainer!
     var animator: ZFModalTransitionAnimator!
     var pageIndicatorView: FolioReaderPageIndicator!
     var bookShareLink: String?

--- a/Source/FolioReaderContainer.swift
+++ b/Source/FolioReaderContainer.swift
@@ -23,7 +23,7 @@ enum SlideOutState {
     }
 }
 
-protocol FolioReaderContainerDelegate {
+protocol FolioReaderContainerDelegate: class {
     /**
     Notifies that the menu was expanded.
     */
@@ -78,7 +78,7 @@ class FolioReaderContainer: UIViewController, FolioReaderSidePanelDelegate {
             kCurrentAudioRate: 1,
             kCurrentHighlightStyle: 0,
             kCurrentMediaOverlayStyle: MediaOverlayStyle.Default.rawValue
-            ])
+        ])
     }
     
     // MARK: - View life cicle

--- a/Source/FolioReaderKit.swift
+++ b/Source/FolioReaderKit.swift
@@ -58,10 +58,10 @@ public class FolioReader : NSObject {
     
     static let sharedInstance = FolioReader()
     static let defaults = NSUserDefaults.standardUserDefaults()
-    var readerCenter: FolioReaderCenter!
-    var readerSidePanel: FolioReaderSidePanel!
-    var readerContainer: FolioReaderContainer!
-    var readerAudioPlayer: FolioReaderAudioPlayer!
+    weak var readerCenter: FolioReaderCenter!
+    weak var readerSidePanel: FolioReaderSidePanel!
+    weak var readerContainer: FolioReaderContainer!
+    weak var readerAudioPlayer: FolioReaderAudioPlayer!
     var isReaderOpen = false
     var isReaderReady = false
     

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -19,7 +19,7 @@ class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRecogni
     
     var pageNumber: Int!
     var webView: UIWebView!
-    var delegate: FolioPageDelegate!
+    weak var delegate: FolioPageDelegate!
     private var shouldShowBar = true
     private var menuIsVisible = false
     

--- a/Source/FolioReaderSidePanel.swift
+++ b/Source/FolioReaderSidePanel.swift
@@ -18,7 +18,7 @@ protocol FolioReaderSidePanelDelegate {
 
 class FolioReaderSidePanel: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-    var delegate: FolioReaderSidePanelDelegate?
+    weak var delegate: FolioReaderSidePanelDelegate?
     var tableView: UITableView!
     var toolBar: UIToolbar!
     let toolBarHeight: CGFloat = 50


### PR DESCRIPTION
Profiling in Instruments revealed a retain cycle problem. After dismissing FolioReaderContainer still keeps living along with several other objects (FolioReaderCenter, FolioReaderAudioPlayer and so on).

My commit only fixes a use case when FolioReaderContainer is modally presented and then immediately dismissed. No other interactions (e.g. chapter navigation, sharing etc.) were performed. So I suggest a better inspection.

I also noticed that in FolioReaderContainer.swift there are three static variables: readerConfig, epubPath and book. These variables also stay alive after dismissing VC. Maybe FolioReader is a better place for them?
