### PR TITLE
Added a bugfix to UIWebViews canPerformAction category

### DIFF
--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -425,6 +425,10 @@ extension UIWebView {
     }
     
     public override func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
+        
+        if(readerConfig == nil){
+            return super.canPerformAction(action, withSender: sender)
+        }
 
         // menu on existing highlight
         if isShare {


### PR DESCRIPTION
Added a bugfix to UIWebViews canPerformAction category to prevent foreign webviews from crashing. 

If you use a non FolioReaderKit WebView and select some text, it calls the canPerformAction method and crashes since no readerConfig is defined.
