### PR TITLE
Add option to en-/disable the scrolling between chapters - #134

### DIFF
--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -76,6 +76,7 @@ public class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICo
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.backgroundColor = background
         collectionView.decelerationRate = UIScrollViewDecelerationRateFast
+		enableScrollBetweenChapers(scrollEnabled: true)
         view.addSubview(collectionView)
         
         // Register cell classes
@@ -128,6 +129,15 @@ public class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICo
 	}
 
 	// MARK: Layout
+
+	/**
+	Enable or disable the scrolling between chapters (`FolioReaderPage`s). If this is enabled it's only possible to read the current chapter. If another chapter should be displayed is has to be triggered programmatically with `changePageWith`.
+
+	- parameter scrollEnabled: `Bool` which enables or disables the scrolling between `FolioReaderPage`s.
+	*/
+	public func enableScrollBetweenChapers(scrollEnabled scrollEnabled: Bool) {
+		self.collectionView.scrollEnabled = scrollEnabled
+	}
 
 	private func updateSubviewFrames() {
 		self.pageIndicatorView?.frame = self.frameForPageIndicatorView()

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -76,7 +76,7 @@ public class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICo
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.backgroundColor = background
         collectionView.decelerationRate = UIScrollViewDecelerationRateFast
-		enableScrollBetweenChapers(scrollEnabled: true)
+		enableScrollBetweenChapters(scrollEnabled: true)
         view.addSubview(collectionView)
         
         // Register cell classes
@@ -135,7 +135,7 @@ public class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICo
 
 	- parameter scrollEnabled: `Bool` which enables or disables the scrolling between `FolioReaderPage`s.
 	*/
-	public func enableScrollBetweenChapers(scrollEnabled scrollEnabled: Bool) {
+	public func enableScrollBetweenChapters(scrollEnabled scrollEnabled: Bool) {
 		self.collectionView.scrollEnabled = scrollEnabled
 	}
 


### PR DESCRIPTION
Implementes https://github.com/FolioReader/FolioReaderKit/issues/134.

I have not added config as I think it would be confusing if scrollEnabled can be set in the config and than be changed later with a method (without updating the config). To change the config later and than update the collection view with this state would be a complicated usage. I think the config should be for settings which don't change during the usage of a reader instance. 

What do you think?
