### PR TITLE
Expose `pageDidLoad` method to external code

### DIFF
--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -21,6 +21,9 @@ var isScrolling = false
 
 public class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource {
 
+	/// This delegate receives the events from the current `FolioReaderPage`s delegate.
+	public weak var pageDelegate: FolioReaderPageDelegate?
+
     var collectionView: UICollectionView!
     let collectionViewLayout = UICollectionViewFlowLayout()
     var loadingView: UIActivityIndicatorView!
@@ -1093,7 +1096,7 @@ public class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UICo
 
 extension FolioReaderCenter: FolioReaderPageDelegate {
     
-    func pageDidLoad(page: FolioReaderPage) {
+    public func pageDidLoad(page: FolioReaderPage) {
         
         if let position = FolioReader.defaults.valueForKey(kBookId) as? NSDictionary {
             let pageNumber = position["pageNumber"]! as! Int
@@ -1125,6 +1128,8 @@ extension FolioReaderCenter: FolioReaderPageDelegate {
 			let offsetPoint = self.currentWebViewScrollPositions[page.pageNumber - 1] {
 				page.webView.scrollView.setContentOffset(offsetPoint, animated: false)
 		}
+
+		self.pageDelegate?.pageDidLoad(page)
     }
 }
 

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -24,8 +24,9 @@ public protocol FolioReaderPageDelegate: class {
 public class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRecognizerDelegate {
     
     weak var delegate: FolioReaderPageDelegate?
-    var pageNumber: Int!
-    var webView: UIWebView!
+	/// The index of the current page. Note: The index start at 1!
+	public var pageNumber: Int!
+	var webView: UIWebView!
     private var colorView: UIView!
     private var shouldShowBar = true
     private var menuIsVisible = false

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -11,7 +11,8 @@ import SafariServices
 import UIMenuItem_CXAImageSupport
 import JSQWebViewController
 
-protocol FolioReaderPageDelegate: class {
+/// Protocol which is used from `FolioReaderPage`s.
+public protocol FolioReaderPageDelegate: class {
     /**
      Notify that page did loaded
      


### PR DESCRIPTION
Expose `pageDidLoad` method to external code within the `FolioReaderCenter`.
