### PR TITLE
Use SSZipArchive version 1.5

### DIFF
--- a/FolioReaderKit.podspec
+++ b/FolioReaderKit.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   s.libraries  = "z"
   s.frameworks = 'CoreData'
-  s.dependency 'SSZipArchive', '~> 1.3'
+  s.dependency 'SSZipArchive', '1.5'
   s.dependency 'UIMenuItem-CXAImageSupport', '~> 0.0'
   s.dependency 'ZFDragableModalTransition', '~> 0.6'
   s.dependency 'AEXML', '~> 3.0'


### PR DESCRIPTION
The folio reader crashed during the opening of an epub using SSZipArchive version 1.6.1. With SSZipArchive version 1.5 it's working again.

Might fix #144 and #146
