### PR TITLE
Provide a config which disables the readers `UIMenuController`

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -9,7 +9,7 @@ end
 
 def testing_pods
   pod 'Quick', '0.9.2'
-  pod 'Nimble'
+  pod 'Nimble', '~> 4.1.0' 
 end
 
 target 'Example' do

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,23 +12,23 @@ PODS:
   - JSQWebViewController (3.0.0)
   - Nimble (4.1.0)
   - Quick (0.9.2)
-  - Realm (1.0.2):
-    - Realm/Headers (= 1.0.2)
-  - Realm/Headers (1.0.2)
-  - RealmSwift (1.0.2):
-    - Realm (= 1.0.2)
+  - Realm (1.1.0):
+    - Realm/Headers (= 1.1.0)
+  - Realm/Headers (1.1.0)
+  - RealmSwift (1.1.0):
+    - Realm (= 1.1.0)
   - SSZipArchive (1.5)
   - UIMenuItem-CXAImageSupport (0.0.1)
   - ZFDragableModalTransition (0.6)
 
 DEPENDENCIES:
   - FolioReaderKit (from `../`)
-  - Nimble
+  - Nimble (~> 4.1.0)
   - Quick (= 0.9.2)
 
 EXTERNAL SOURCES:
   FolioReaderKit:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   AEXML: 716fb0a8decba4a3517324a71fee3685b30233d2
@@ -37,12 +37,12 @@ SPEC CHECKSUMS:
   JSQWebViewController: eaa6bd68d9e1426ae25ade99c9bbde4c6cdd4120
   Nimble: 97a0a4cae5124c117115634b2d055d8c97d0af19
   Quick: 18d057bc66451eedd5d1c8dc99ba2a5db6e60226
-  Realm: 9d5c46a4d7d27958530a8dfc58f63a99e5c2cba3
-  RealmSwift: 82f3ac5e24530143dddfde2033acc0d308f27d96
+  Realm: ceecf1a4540c4ce9efe196fe73fa9855bce05bd8
+  RealmSwift: 838058b2db95b12cb86bd0cf209df642c33fb60a
   SSZipArchive: 29daace2bccb90a47de2837744da397728ff9207
   UIMenuItem-CXAImageSupport: 2945e2af4487414caad801ed8ff6ac8db274e986
   ZFDragableModalTransition: 0d294eaaba6edfcb9839595de765f9ca06a4b524
 
-PODFILE CHECKSUM: 019ed1399429245758bdf9b0c090c4b685a25030
+PODFILE CHECKSUM: 617d506c4ff6fef0fcf4032d9acdc7ee8ad208e9
 
 COCOAPODS: 1.0.1

--- a/Source/FolioReaderConfig.swift
+++ b/Source/FolioReaderConfig.swift
@@ -164,7 +164,10 @@ public class FolioReaderConfig: NSObject {
    
     /// Localizes Content title
     public var localizedContentsTitle = NSLocalizedString("Contents", comment: "")
- 
+
+	/// Use the readers `UIMenuController` which enables the highlighting etc. The default is `true`. If set to false it's possible to modify the shared `UIMenuController` for yourself. Note: This doesn't disable the text selection in the web view.
+	public var useReaderMenuController = true
+	
     /// Localizes Highlight date format. This is a `dateFormat` from `NSDateFormatter`, so be careful 🤔
     public var localizedHighlightsDateFormat = "MMM dd, YYYY | HH:mm"
     public var localizedHighlightMenu = NSLocalizedString("Highlight", comment: "")

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -425,10 +425,6 @@ public class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGesture
     // MARK: UIMenu visibility
     
     override public func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
-		guard readerConfig.useReaderMenuController else {
-			return false
-		}
-
 		if UIMenuController.sharedMenuController().menuItems?.count == 0 {
             webView.isColors = false
             webView.createMenu(options: false)

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -425,7 +425,11 @@ public class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGesture
     // MARK: UIMenu visibility
     
     override public func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
-        if UIMenuController.sharedMenuController().menuItems?.count == 0 {
+		guard readerConfig.useReaderMenuController else {
+			return false
+		}
+
+		if UIMenuController.sharedMenuController().menuItems?.count == 0 {
             webView.isColors = false
             webView.createMenu(options: false)
         }
@@ -478,7 +482,10 @@ extension UIWebView {
     }
     
     public override func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
-        
+		guard readerConfig.useReaderMenuController else {
+			return false
+		}
+
         if(readerConfig == nil){
             return super.canPerformAction(action, withSender: sender)
         }
@@ -656,7 +663,11 @@ extension UIWebView {
     // MARK: - Create and show menu
     
     func createMenu(options options: Bool) {
-        isShare = options
+		guard readerConfig.useReaderMenuController else {
+			return
+		}
+
+		isShare = options
         
         let colors = UIImage(readerImageNamed: "colors-marker")
         let share = UIImage(readerImageNamed: "share-marker")
@@ -685,7 +696,11 @@ extension UIWebView {
     }
     
     func setMenuVisible(menuVisible: Bool, animated: Bool = true, andRect rect: CGRect = CGRectZero) {
-        if !menuVisible && isShare || !menuVisible && isColors {
+		guard readerConfig.useReaderMenuController else {
+			return
+		}
+
+		if !menuVisible && isShare || !menuVisible && isColors {
             isColors = false
             isShare = false
         }

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -692,10 +692,6 @@ extension UIWebView {
     }
     
     func setMenuVisible(menuVisible: Bool, animated: Bool = true, andRect rect: CGRect = CGRectZero) {
-		guard readerConfig.useReaderMenuController else {
-			return
-		}
-
 		if !menuVisible && isShare || !menuVisible && isColors {
             isColors = false
             isShare = false

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -193,7 +193,7 @@ public class FolioReaderWebView: UIWebView {
 	// MARK: - Create and show menu
 
 	func createMenu(options options: Bool) {
-		guard readerConfig.useReaderMenuController == false else {
+		guard readerConfig.useReaderMenuController else {
 			return
 		}
 

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class FolioReaderWebView: UIWebView {
+public class FolioReaderWebView: UIWebView {
 
 	var isColors = false
 	var isShare = false
@@ -17,7 +17,7 @@ class FolioReaderWebView: UIWebView {
 
 	public override func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
 
-		if(readerConfig == nil){
+		if(readerConfig == nil || readerConfig.useReaderMenuController == false) {
 			return super.canPerformAction(action, withSender: sender)
 		}
 
@@ -193,6 +193,10 @@ class FolioReaderWebView: UIWebView {
 	// MARK: - Create and show menu
 
 	func createMenu(options options: Bool) {
+		guard readerConfig.useReaderMenuController == false else {
+			return
+		}
+
 		isShare = options
 
 		let colors = UIImage(readerImageNamed: "colors-marker")


### PR DESCRIPTION
This PR adds a config which makes it possible to disable the default reader menu controller. By deactivating this it's possible for us to use custom menu entries.
