### PR TITLE
Fix incorrect menu on second highlight attempt

### DIFF
--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -112,7 +112,7 @@ open class FolioReaderWebView: UIWebView {
 			isUserInteractionEnabled = false
 			isUserInteractionEnabled = true
 
-			createMenu(options: true)
+			createMenu(options: false)
 			setMenuVisible(true, andRect: rect)
 
 			// Persist


### PR DESCRIPTION
This fixes #170.

I don't get what the logic is behind this. Why is `createMenu` called on menu dismiss, and not on menu show? Is it a sort of pre-rendering? What does the `setMenuVisible(true, andRect: rect)` call do? As it clearly doesn't show the menu, as it is being dismissed at that point.

Nonetheless, it looks like, somehow, on long tap, the correct menu appears all the time, so there's no need to force the "share" menu.