### PR TITLE
Fix scroll direction being ignored on first run

### DIFF
--- a/Source/FolioReaderConfig.swift
+++ b/Source/FolioReaderConfig.swift
@@ -23,7 +23,10 @@ public enum FolioReaderScrollDirection: Int {
     
     /// Sections scroll horizontal and content scroll on vertical
 	case horizontalWithVerticalContent
-    
+
+    /// The default scroll direction, if not overridden; works as .vertical
+    case defaultVertical
+
     /**
      The current scroll direction
      
@@ -31,7 +34,7 @@ public enum FolioReaderScrollDirection: Int {
      */
     func collectionViewScrollDirection() -> UICollectionViewScrollDirection {
         switch self {
-        case .vertical:
+        case .vertical, .defaultVertical:
             return .vertical
         case .horizontal, .horizontalWithVerticalContent:
             return .horizontal
@@ -132,7 +135,7 @@ open class FolioReaderConfig: NSObject {
 	open var hideBars = false
 
     /// If `canChangeScrollDirection` is `true` it will be overrided by user's option.
-    open var scrollDirection: FolioReaderScrollDirection = .vertical
+    open var scrollDirection: FolioReaderScrollDirection = .defaultVertical
     
     /// Enable or disable hability to user change scroll direction on menu.
     open var canChangeScrollDirection = true

--- a/Source/FolioReaderContainer.swift
+++ b/Source/FolioReaderContainer.swift
@@ -69,7 +69,7 @@ open class FolioReaderContainer: UIViewController {
             kCurrentHighlightStyle: 0,
             kCurrentTOCMenu: 0,
             kCurrentMediaOverlayStyle: MediaOverlayStyle.default.rawValue,
-            kCurrentScrollDirection: FolioReaderScrollDirection.vertical.rawValue
+            kCurrentScrollDirection: FolioReaderScrollDirection.defaultVertical.rawValue
             ])
     }
     
@@ -95,8 +95,13 @@ open class FolioReaderContainer: UIViewController {
         
         // If user can change scroll direction use the last saved
         if readerConfig.canChangeScrollDirection {
-            let direction = FolioReaderScrollDirection(rawValue: FolioReader.currentScrollDirection) ?? .vertical
-            readerConfig.scrollDirection = direction
+            var scrollDirection = FolioReaderScrollDirection(rawValue: FolioReader.currentScrollDirection) ?? .vertical
+
+            if (scrollDirection == .defaultVertical && readerConfig.scrollDirection != .defaultVertical) {
+                scrollDirection = readerConfig.scrollDirection
+            }
+
+            readerConfig.scrollDirection = scrollDirection
         }
 
 		readerConfig.shouldHideNavigationOnTap = ((readerConfig.hideBars == true) ? true : readerConfig.shouldHideNavigationOnTap)

--- a/Source/FolioReaderFontsMenu.swift
+++ b/Source/FolioReaderFontsMenu.swift
@@ -234,7 +234,14 @@ class FolioReaderFontsMenu: UIViewController, SMSegmentViewDelegate, UIGestureRe
         layoutDirection.tag = 3
         layoutDirection.addSegmentWithTitle(readerConfig.localizedLayoutVertical, onSelectionImage: verticalSelected, offSelectionImage: verticalNormal)
         layoutDirection.addSegmentWithTitle(readerConfig.localizedLayoutHorizontal, onSelectionImage: horizontalSelected, offSelectionImage: horizontalNormal)
-        layoutDirection.selectSegmentAtIndex(Int(FolioReader.currentScrollDirection))
+
+        var scrollDirection = FolioReaderScrollDirection(rawValue: FolioReader.currentScrollDirection)
+
+        if scrollDirection == .defaultVertical && readerConfig.scrollDirection != .defaultVertical {
+            scrollDirection = readerConfig.scrollDirection
+        }
+
+        layoutDirection.selectSegmentAtIndex(scrollDirection?.rawValue ?? 0)
         menuView.addSubview(layoutDirection)
     }
     

--- a/Source/FolioReaderKit.swift
+++ b/Source/FolioReaderKit.swift
@@ -163,7 +163,7 @@ open class FolioReader: NSObject {
             FolioReader.defaults.setValue(value, forKey: kCurrentScrollDirection)
 
 			if let _readerCenter = FolioReader.shared.readerCenter  {
-				let direction = FolioReaderScrollDirection(rawValue: currentScrollDirection) ?? .vertical
+				let direction = FolioReaderScrollDirection(rawValue: currentScrollDirection) ?? .defaultVertical
 				_readerCenter.setScrollDirection(direction)
 			}
         }
@@ -266,7 +266,7 @@ func isNight<T> (_ f: T, _ l: T) -> T {
  */
 func isDirection<T> (_ vertical: T, _ horizontal: T, _ horizontalContentVertical: T? = nil) -> T {
 	switch readerConfig.scrollDirection {
-	case .vertical: return vertical
+	case .vertical, .defaultVertical: return vertical
 	case .horizontal: return horizontal
 	case .horizontalWithVerticalContent: return horizontalContentVertical ?? vertical
 	}

--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -396,7 +396,8 @@ open class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRe
 		if !anchor.isEmpty {
 			let offset = getAnchorOffset(anchor)
 
-			if readerConfig.scrollDirection == .vertical {
+			switch readerConfig.scrollDirection {
+            case .vertical, .defaultVertical:
 				let isBeginning = offset < frame.forDirection()/2
 
 				if !avoidBeginningAnchors {
@@ -404,7 +405,7 @@ open class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRe
 				} else if avoidBeginningAnchors && !isBeginning {
 					scrollPageToOffset(offset, animated: animated)
 				}
-			} else {
+            case .horizontal, .horizontalWithVerticalContent:
 				scrollPageToOffset(offset, animated: animated)
 			}
 		}

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -277,7 +277,7 @@ open class FolioReaderWebView: UIWebView {
 
 	func setupScrollDirection() {
 		switch readerConfig.scrollDirection {
-		case .vertical, .horizontalWithVerticalContent:
+		case .vertical, .defaultVertical, .horizontalWithVerticalContent:
 			scrollView.isPagingEnabled = false
 			paginationMode = .unpaginated
 			scrollView.bounces = true

--- a/Source/ScrollScrubber.swift
+++ b/Source/ScrollScrubber.swift
@@ -174,7 +174,7 @@ class ScrollScrubber: NSObject, UIScrollViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard readerConfig.scrollDirection == .vertical || readerConfig.scrollDirection == .horizontalWithVerticalContent else {
+        guard readerConfig.scrollDirection == .vertical || readerConfig.scrollDirection == .defaultVertical || readerConfig.scrollDirection == .horizontalWithVerticalContent else {
             return
         }
         


### PR DESCRIPTION
Setting currentScrollDirection to .horizontal was ignored before the
user changed it manually. Now, setting it like mentioned, the book
scrolls horizontally as expected, and if the user changes it to
vertical, it is respected by the app. Not setting the property still
scrolls vertically by default, as before.