### PR TITLE
set webView's scroll delegate to nil in deinit in FolioReaderPage

### DIFF
--- a/Source/FolioReaderPage.swift
+++ b/Source/FolioReaderPage.swift
@@ -77,6 +77,7 @@ open class FolioReaderPage: UICollectionViewCell, UIWebViewDelegate, UIGestureRe
     }
     
     deinit {
+        webView.scrollView.delegate = nil
         NotificationCenter.default.removeObserver(self)
     }
     


### PR DESCRIPTION
In order to prevent dangling pointer in FolioReaderPage from this issue https://github.com/FolioReader/FolioReaderKit/issues/187