### PR TITLE
Fixed crash caused by resource.id set to nil.

### DIFF
--- a/Source/EPUBCore/FRResources.swift
+++ b/Source/EPUBCore/FRResources.swift
@@ -81,7 +81,7 @@ class FRResources: NSObject {
         guard let id = id else { return nil }
         
         for resource in resources.values {
-            if resource.id == id {
+            if let resourceID = resource.id, resourceID == id {
                 return resource
             }
         }
@@ -104,7 +104,7 @@ class FRResources: NSObject {
         guard let id = id else { return false }
         
         for resource in resources.values {
-            if resource.id == id {
+            if let resourceID = resource.id, resourceID == id {
                 return true
             }
         }


### PR DESCRIPTION
I've encountered an issue when not all _item_ tags in *.opf file had _id_ properly set. It is an easy fix to avoid crash caused by that.