### PR TITLE
Map scroll directions to actual segment indices in fonts menu

### DIFF
--- a/Source/FolioReaderFontsMenu.swift
+++ b/Source/FolioReaderFontsMenu.swift
@@ -243,7 +243,12 @@ class FolioReaderFontsMenu: UIViewController, SMSegmentViewDelegate, UIGestureRe
             scrollDirection = readerConfig.scrollDirection
         }
 
-        layoutDirection.selectSegmentAtIndex(scrollDirection?.rawValue ?? 0)
+        switch scrollDirection ?? .vertical {
+        case .vertical, .defaultVertical:
+            layoutDirection.selectSegmentAtIndex(FolioReaderScrollDirection.vertical.rawValue)
+        case .horizontal, .horizontalWithVerticalContent:
+            layoutDirection.selectSegmentAtIndex(FolioReaderScrollDirection.horizontal.rawValue)
+        }
         menuView.addSubview(layoutDirection)
     }
     


### PR DESCRIPTION
This is intended to fix the crash in #215. The only options in the menu are vertical and horizontal, so the UI excludes the horizontalWithVerticalContent option, but that option seems to be only configurable programmatically and is incompatible with letting the user select a scroll direction.