### PR TITLE
Fix horizontal scroll direction not working

### DIFF
--- a/Source/FolioReaderKit.swift
+++ b/Source/FolioReaderKit.swift
@@ -271,7 +271,7 @@ extension FolioReader {
     /// Check the current scroll direction. Default .defaultVertical
     open var currentScrollDirection: Int {
         get {
-            guard let value = self.defaults.integer(forKey: kCurrentScrollDirection) as? Int else {
+            guard let value = self.defaults.value(forKey: kCurrentScrollDirection) as? Int else {
                 return FolioReaderScrollDirection.defaultVertical.rawValue
             }
 


### PR DESCRIPTION
Setting the scroll direction to horizontal on the config was
ignored because the current scroll direction returned 0 instead of
nil on the first run, so it never reaches the guard's else block.

Introduced by #237.
Related to #178.