### PR TITLE
Add custom unzip path setting to FolioReaderContainer

### DIFF
--- a/Source/EPUBCore/FREpubParser.swift
+++ b/Source/EPUBCore/FREpubParser.swift
@@ -45,7 +45,7 @@ class FREpubParser: NSObject, SSZipArchiveDelegate {
     ///
     /// - Parameters:
     ///   - epubPath: Epub path on the disk.
-    ///   - unzipPath: Path to unzip the compressed pub.
+    ///   - unzipPath: Path to unzip the compressed epub.
     /// - Returns: The book title
     /// - Throws: `FolioReaderError`
     func parseTitle(_ epubPath: String, unzipPath: String? = nil) throws -> String {
@@ -60,7 +60,7 @@ class FREpubParser: NSObject, SSZipArchiveDelegate {
     ///
     /// - Parameters:
     ///   - epubPath: Epub path on the disk.
-    ///   - unzipPath: Path to unzip the compressed pub.
+    ///   - unzipPath: Path to unzip the compressed epub.
     /// - Returns: The author name
     /// - Throws: `FolioReaderError`
     func parseAuthorName(_ epubPath: String, unzipPath: String? = nil) throws -> String {
@@ -75,7 +75,7 @@ class FREpubParser: NSObject, SSZipArchiveDelegate {
     /// - Parameters:
     ///   - withEpubPath: Epub path on the disk
     ///   - removeEpub: Should remove the original file?
-    ///   - unzipPath: The path to unzip
+    ///   - unzipPath: Path to unzip the compressed epub.
     /// - Returns: `FRBook` Object
     /// - Throws: `FolioReaderError`
     func readEpub(epubPath withEpubPath: String, removeEpub: Bool = true, unzipPath: String? = nil) throws -> FRBook {

--- a/Source/FolioReaderContainer.swift
+++ b/Source/FolioReaderContainer.swift
@@ -16,6 +16,7 @@ open class FolioReaderContainer: UIViewController {
     
     // Mark those property as public so they can accessed from other classes/subclasses.
     public var epubPath: String
+	public var unzipPath: String?
     public var book: FRBook
     
     public var centerNavigationController: UINavigationController?
@@ -35,11 +36,13 @@ open class FolioReaderContainer: UIViewController {
     ///   - config: Current Folio Reader configuration
     ///   - folioReader: Current instance of the FolioReader kit.
     ///   - path: The ePub path on system. Must not be nil nor empty string.
+	///   - unzipPath: Path to unzip the compressed epub.
     ///   - removeEpub: Should delete the original file after unzip? Default to `true` so the ePub will be unziped only once.
-    public init(withConfig config: FolioReaderConfig, folioReader: FolioReader, epubPath path: String, removeEpub: Bool = true) {
+    public init(withConfig config: FolioReaderConfig, folioReader: FolioReader, epubPath path: String, unzipPath: String? = nil, removeEpub: Bool = true) {
         self.readerConfig = config
         self.folioReader = folioReader
         self.epubPath = path
+		self.unzipPath = unzipPath
         self.shouldRemoveEpub = removeEpub
         self.book = FRBook()
 
@@ -97,12 +100,14 @@ open class FolioReaderContainer: UIViewController {
     /// - Parameters:
     ///   - config: Current Folio Reader configuration
     ///   - path: The ePub path on system. Must not be nil nor empty string.
+	///   - unzipPath: Path to unzip the compressed epub.
     ///   - removeEpub: Should delete the original file after unzip? Default to `true` so the ePub will be unziped only once.
-    open func setupConfig(_ config: FolioReaderConfig, epubPath path: String, removeEpub: Bool = true) {
+    open func setupConfig(_ config: FolioReaderConfig, epubPath path: String, unzipPath: String? = nil, removeEpub: Bool = true) {
         self.readerConfig = config
         self.folioReader = FolioReader()
         self.folioReader.readerContainer = self
         self.epubPath = path
+		self.unzipPath = unzipPath
         self.shouldRemoveEpub = removeEpub
 
         // Set the shared instance to support old version.
@@ -159,7 +164,7 @@ open class FolioReaderContainer: UIViewController {
         DispatchQueue.global(qos: .userInitiated).async {
 
             do {
-                guard let parsedBook = try? FREpubParser().readEpub(epubPath: self.epubPath, removeEpub: self.shouldRemoveEpub) else {
+                guard let parsedBook = try? FREpubParser().readEpub(epubPath: self.epubPath, removeEpub: self.shouldRemoveEpub, unzipPath: self.unzipPath) else {
                     self.errorOnLoad = true
                     return
                 }

--- a/Source/FolioReaderContainer.swift
+++ b/Source/FolioReaderContainer.swift
@@ -35,7 +35,7 @@ open class FolioReaderContainer: UIViewController {
     ///   - config: Current Folio Reader configuration
     ///   - folioReader: Current instance of the FolioReader kit.
     ///   - path: The ePub path on system. Must not be nil nor empty string.
-    ///   - removeEpub:  Should delete the original file after unzip? Default to `true` so the ePub will be unziped only once.
+    ///   - removeEpub: Should delete the original file after unzip? Default to `true` so the ePub will be unziped only once.
     public init(withConfig config: FolioReaderConfig, folioReader: FolioReader, epubPath path: String, removeEpub: Bool = true) {
         self.readerConfig = config
         self.folioReader = folioReader

--- a/Source/FolioReaderKit.swift
+++ b/Source/FolioReaderKit.swift
@@ -156,12 +156,13 @@ extension FolioReader {
     /// - Parameters:
     ///   - parentViewController: View Controller that will present the reader container.
     ///   - epubPath: String representing the path on the disk of the ePub file. Must not be nil nor empty string.
+	///   - unzipPath: Path to unzip the compressed epub.
     ///   - config: FolioReader configuration.
     ///   - shouldRemoveEpub: Boolean to remove the epub or not. Default true.
     ///   - animated: Pass true to animate the presentation; otherwise, pass false.
-    open func presentReader(parentViewController: UIViewController, withEpubPath epubPath: String, andConfig config: FolioReaderConfig, shouldRemoveEpub: Bool = true, animated:
+    open func presentReader(parentViewController: UIViewController, withEpubPath epubPath: String, unzipPath: String? = nil, andConfig config: FolioReaderConfig, shouldRemoveEpub: Bool = true, animated:
         Bool = true) {
-        var readerContainer = FolioReaderContainer(withConfig: config, folioReader: self, epubPath: epubPath, removeEpub: shouldRemoveEpub)
+        var readerContainer = FolioReaderContainer(withConfig: config, folioReader: self, epubPath: epubPath, unzipPath: unzipPath, removeEpub: shouldRemoveEpub)
         self.readerContainer = readerContainer
         parentViewController.present(readerContainer, animated: animated, completion: nil)
         addObservers()


### PR DESCRIPTION
This allows writing:

```swift
import FolioReaderKit

func open(sender: AnyObject) {
    let config = FolioReaderConfig()
    let bookPath = Bundle.main.path(forResource: "book", ofType: "epub")
    let folioReader = FolioReader()
    folioReader.presentReader(parentViewController: self, withEpubPath: bookPath!, unzipPath: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("books"), andConfig: config)
}
```

or

```swift
import FolioReaderKit

class StoryboardFolioReaderContrainer: FolioReaderContainer {
    required init?(coder aDecoder: NSCoder) {
        super.init(coder: aDecoder)
        
        let config = FolioReaderConfig()
        config.scrollDirection = .horizontalWithVerticalContent
        
        guard let bookPath = Bundle.main.path(forResource: "The Silver Chair", ofType: "epub") else { return }
        setupConfig(config, epubPath: bookPath, unzipPath: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("books"))
    }
}
```