### PR TITLE
Reader takes over the audio control

### DIFF
--- a/Source/FolioReaderAudioPlayer.swift
+++ b/Source/FolioReaderAudioPlayer.swift
@@ -43,7 +43,12 @@ open class FolioReaderAudioPlayer: NSObject {
         // this is needed to the audio can play even when the "silent/vibrate" toggle is on
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(AVAudioSessionCategoryPlayback)
-        try? session.setActive(true)
+
+        NotificationCenter.default.addObserver(self,
+            selector: #selector(pause),
+            name: .AVAudioSessionInterruption,
+            object: session
+        )
 
         self.updateNowPlayingInfo()
     }


### PR DESCRIPTION
- Removed code that sets reader audio session to active immediately after pod init
- Added audio session interruption observer to update player/player menu state
- Closes #321