### PR TITLE
FolioReaderCenter.getCurrentChapterName() issue, applied recursive search for toc reference.

### DIFF
--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -157,10 +157,6 @@ open class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UIColl
         enableScrollBetweenChapters(scrollEnabled: true)
         view.addSubview(collectionView)
 
-        if #available(iOS 11.0, *) {
-            collectionView.contentInsetAdjustmentBehavior = .never
-        }
-
         // Activity Indicator
         self.activityIndicator.activityIndicatorViewStyle = .gray
         self.activityIndicator.hidesWhenStopped = true

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -156,6 +156,10 @@ open class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UIColl
         collectionView.decelerationRate = UIScrollViewDecelerationRateFast
         enableScrollBetweenChapters(scrollEnabled: true)
         view.addSubview(collectionView)
+        
+        if #available(iOS 11.0, *) {
+            collectionView.contentInsetAdjustmentBehavior = .never
+        }
 
         // Activity Indicator
         self.activityIndicator.activityIndicatorViewStyle = .gray

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -996,19 +996,25 @@ open class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UIColl
      Find and return the current chapter name.
      */
     public func getCurrentChapterName() -> String? {
-        for item in self.book.flatTableOfContents {
-            guard
-                let reference = self.book.spine.spineReferences[safe: (self.currentPageNumber - 1)],
-                let resource = item.resource,
-                (resource == reference.resource),
-                let title = item.title else {
-                    continue
+        var foundChapterName: String?
+        
+        func search(_ items: [FRTocReference]) {
+            for item in items {
+                guard foundChapterName == nil else { break }
+                
+                if let reference = self.book.spine.spineReferences[safe: (self.currentPageNumber - 1)],
+                    let resource = item.resource,
+                    resource == reference.resource,
+                    let title = item.title {
+                    foundChapterName = title
+                } else if let children = item.children, children.isEmpty == false {
+                    search(children)
+                }
             }
-
-            return title
         }
-
-        return nil
+        search(self.book.flatTableOfContents)
+        
+        return foundChapterName
     }
 
     // MARK: Public page methods

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -996,25 +996,19 @@ open class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UIColl
      Find and return the current chapter name.
      */
     public func getCurrentChapterName() -> String? {
-        var foundChapterName: String?
-        
-        func search(_ items: [FRTocReference]) {
-            for item in items {
-                guard foundChapterName == nil else { break }
-                
-                if let reference = self.book.spine.spineReferences[safe: (self.currentPageNumber - 1)],
-                    let resource = item.resource,
-                    resource == reference.resource,
-                    let title = item.title {
-                    foundChapterName = title
-                } else if let children = item.children, children.isEmpty == false {
-                    search(children)
-                }
+        for item in self.book.flatTableOfContents {
+            guard
+                let reference = self.book.spine.spineReferences[safe: (self.currentPageNumber - 1)],
+                let resource = item.resource,
+                (resource == reference.resource),
+                let title = item.title else {
+                    continue
             }
+
+            return title
         }
-        search(self.book.flatTableOfContents)
-        
-        return foundChapterName
+
+        return nil
     }
 
     // MARK: Public page methods

--- a/Source/FolioReaderCenter.swift
+++ b/Source/FolioReaderCenter.swift
@@ -1000,19 +1000,25 @@ open class FolioReaderCenter: UIViewController, UICollectionViewDelegate, UIColl
      Find and return the current chapter name.
      */
     public func getCurrentChapterName() -> String? {
-        for item in self.book.flatTableOfContents {
-            guard
-                let reference = self.book.spine.spineReferences[safe: (self.currentPageNumber - 1)],
-                let resource = item.resource,
-                (resource == reference.resource),
-                let title = item.title else {
-                    continue
+        var foundChapterName: String?
+        
+        func search(_ items: [FRTocReference]) {
+            for item in items {
+                guard foundChapterName == nil else { break }
+                
+                if let reference = self.book.spine.spineReferences[safe: (self.currentPageNumber - 1)],
+                    let resource = item.resource,
+                    resource == reference.resource,
+                    let title = item.title {
+                    foundChapterName = title
+                } else if let children = item.children, children.isEmpty == false {
+                    search(children)
+                }
             }
-
-            return title
         }
-
-        return nil
+        search(self.book.flatTableOfContents)
+        
+        return foundChapterName
     }
 
     // MARK: Public page methods

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -246,6 +246,9 @@ open class FolioReaderWebView: UIWebView {
         if let updateId = js("setHighlightStyle('\(HighlightStyle.classForStyle(style.rawValue))')") {
             Highlight.updateById(withConfiguration: self.readerConfig, highlightId: updateId, type: style)
         }
+        
+        //FIX: https://github.com/FolioReader/FolioReaderKit/issues/316
+        setMenuVisible(false)
     }
 
     // MARK: - Create and show menu

--- a/Source/FolioReaderWebView.swift
+++ b/Source/FolioReaderWebView.swift
@@ -246,9 +246,6 @@ open class FolioReaderWebView: UIWebView {
         if let updateId = js("setHighlightStyle('\(HighlightStyle.classForStyle(style.rawValue))')") {
             Highlight.updateById(withConfiguration: self.readerConfig, highlightId: updateId, type: style)
         }
-        
-        //FIX: https://github.com/FolioReader/FolioReaderKit/issues/316
-        setMenuVisible(false)
     }
 
     // MARK: - Create and show menu


### PR DESCRIPTION
Same error that was fixed in ```FolioReaderCenter.getCurrentChapter()```.
Fixed ```FolioReaderCenter.getCurrentChapterName()```, applied recursive search for toc reference.