### PR TITLE
Fix crash on select segment at index. Swift 4.2

### DIFF
--- a/Source/FolioReaderFontsMenu.swift
+++ b/Source/FolioReaderFontsMenu.swift
@@ -141,7 +141,7 @@ class FolioReaderFontsMenu: UIViewController, SMSegmentViewDelegate, UIGestureRe
         dayNight.tag = 1
         dayNight.addSegmentWithTitle(self.readerConfig.localizedFontMenuDay, onSelectionImage: sunSelected, offSelectionImage: sunNormal)
         dayNight.addSegmentWithTitle(self.readerConfig.localizedFontMenuNight, onSelectionImage: moonSelected, offSelectionImage: moonNormal)
-        dayNight.selectSegmentAtIndex(self.folioReader.nightMode.hashValue)
+        dayNight.selectSegmentAtIndex(self.folioReader.nightMode ? 1 : 0)
         menuView.addSubview(dayNight)
 
 


### PR DESCRIPTION
Swift 4.2 has improved hash functions so on a bool type it doesn't return 1 or 0 anymore