### PR TITLE
Jumps to the current chapter when opening chapter list

### DIFF
--- a/Source/FolioReaderChapterList.swift
+++ b/Source/FolioReaderChapterList.swift
@@ -56,6 +56,19 @@ class FolioReaderChapterList: UITableViewController {
 
         // Create TOC list
         self.tocItems = self.book.flatTableOfContents
+      
+        // Jump to the current chapter
+        DispatchQueue.main.async {
+          
+            if
+              let currentPageNumber = self.folioReader.readerCenter?.currentPageNumber,
+              let reference = self.book.spine.spineReferences[safe: currentPageNumber - 1],
+              let index = self.tocItems.firstIndex(where: { $0.resource == reference.resource }) {
+              
+                let indexPath = IndexPath(row: index, section: 0)
+                self.tableView.scrollToRow(at: indexPath, at: .middle, animated: true)
+            }
+        }
     }
 
     // MARK: - Table view data source
@@ -72,7 +85,7 @@ class FolioReaderChapterList: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: kReuseCellIdentifier, for: indexPath) as! FolioReaderChapterListCell
 
         cell.setup(withConfiguration: self.readerConfig)
-        let tocReference = tocItems[(indexPath as NSIndexPath).row]
+        let tocReference = tocItems[indexPath.row]
         let isSection = tocReference.children.count > 0
 
         cell.indexLabel?.text = tocReference.title.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Source/FolioReaderChapterList.swift
+++ b/Source/FolioReaderChapterList.swift
@@ -61,12 +61,12 @@ class FolioReaderChapterList: UITableViewController {
         DispatchQueue.main.async {
           
             if
-              let currentPageNumber = self.folioReader.readerCenter?.currentPageNumber,
-              let reference = self.book.spine.spineReferences[safe: currentPageNumber - 1],
-              let index = self.tocItems.firstIndex(where: { $0.resource == reference.resource }) {
+                let currentPageNumber = self.folioReader.readerCenter?.currentPageNumber,
+                let reference = self.book.spine.spineReferences[safe: currentPageNumber - 1],
+                let index = self.tocItems.firstIndex(where: { $0.resource == reference.resource }) {
               
-                let indexPath = IndexPath(row: index, section: 0)
-                self.tableView.scrollToRow(at: indexPath, at: .middle, animated: true)
+                  let indexPath = IndexPath(row: index, section: 0)
+                  self.tableView.scrollToRow(at: indexPath, at: .middle, animated: true)
             }
         }
     }


### PR DESCRIPTION
Originally when opening the chapter list the `tableView` started at the top. This PR makes the chapter list jump to the current chapter the user is on (based on the `currentPageNumber`).
