### PR TITLE
MPRemoteCommandHandlerStatus crash fix on iOS 13.5

### DIFF
--- a/Source/FolioReaderAudioPlayer.swift
+++ b/Source/FolioReaderAudioPlayer.swift
@@ -515,36 +515,35 @@ open class FolioReaderAudioPlayer: NSObject {
 
         guard !registeredCommands else { return }
         let command = MPRemoteCommandCenter.shared()
-        command.previousTrackCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
+        command.previousTrackCommand.addTarget(handler: { (_) in
             return .success
-        }
+        })
         command.previousTrackCommand.isEnabled = true
 
-        command.nextTrackCommand.addTarget(handler: { (event) in
+        command.nextTrackCommand.addTarget(handler: { (_) in
             self.playNextChapter()
-            return MPRemoteCommandHandlerStatus.success}
-        )
+            return MPRemoteCommandHandlerStatus.success
+        })
         command.nextTrackCommand.isEnabled = true
 
-
-        command.pauseCommand.addTarget(handler: { (event) in
+        command.pauseCommand.addTarget(handler: { (_) in
             self.pause()
-            return MPRemoteCommandHandlerStatus.success}
-        )
+            return MPRemoteCommandHandlerStatus.success
+        })
         command.pauseCommand.isEnabled = true
 
-        command.playCommand.addTarget(handler: { (event) in
+        command.playCommand.addTarget(handler: { (_) in
             self.play()
-            return MPRemoteCommandHandlerStatus.success}
-        )
+            return MPRemoteCommandHandlerStatus.success
+        })
         command.playCommand.isEnabled = true
-
 
         command.togglePlayPauseCommand.addTarget(handler: { (event) in
             self.togglePlay()
-            return MPRemoteCommandHandlerStatus.success}
-        )
+            return MPRemoteCommandHandlerStatus.success
+        })
         command.togglePlayPauseCommand.isEnabled = true
+
         registeredCommands = true
     }
 }

--- a/Source/FolioReaderAudioPlayer.swift
+++ b/Source/FolioReaderAudioPlayer.swift
@@ -514,36 +514,37 @@ open class FolioReaderAudioPlayer: NSObject {
     func registerCommandsIfNeeded() {
 
         guard !registeredCommands else { return }
-
         let command = MPRemoteCommandCenter.shared()
+        command.previousTrackCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
+            return .success
+        }
         command.previousTrackCommand.isEnabled = true
-        command.previousTrackCommand.addTarget(handler: { (event) in
-            self.playPrevChapter()
-            return MPRemoteCommandHandlerStatus.success}
-        )
 
-        command.nextTrackCommand.isEnabled = true
         command.nextTrackCommand.addTarget(handler: { (event) in
             self.playNextChapter()
             return MPRemoteCommandHandlerStatus.success}
         )
+        command.nextTrackCommand.isEnabled = true
 
-        command.pauseCommand.isEnabled = true
+
         command.pauseCommand.addTarget(handler: { (event) in
             self.pause()
             return MPRemoteCommandHandlerStatus.success}
         )
+        command.pauseCommand.isEnabled = true
 
-        command.playCommand.isEnabled = true
         command.playCommand.addTarget(handler: { (event) in
             self.play()
             return MPRemoteCommandHandlerStatus.success}
         )
-        command.togglePlayPauseCommand.isEnabled = true
+        command.playCommand.isEnabled = true
+
+
         command.togglePlayPauseCommand.addTarget(handler: { (event) in
             self.togglePlay()
             return MPRemoteCommandHandlerStatus.success}
         )
+        command.togglePlayPauseCommand.isEnabled = true
         registeredCommands = true
     }
 }


### PR DESCRIPTION
I was experiencing crashes

`Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Unsupported action method signature. Must return MPRemoteCommandHandlerStatus or take a completion handler as the second argument.'`

on iOS 13.5 (iPhone X and iPhone 6s sim) and based on [this](https://developer.apple.com/forums/thread/121540) post it seems 

`MPRemoteCommandCenter.%command%.isEnabled = true`

should be called after adding it's handler

edit: info
